### PR TITLE
Test on trainings

### DIFF
--- a/cog_safe_push/lint.py
+++ b/cog_safe_push/lint.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import subprocess
 import yaml
 
@@ -9,19 +10,37 @@ def lint_predict():
         cog_config = yaml.safe_load(f)
 
     predict_config = cog_config.get("predict", "")
-    predict_filename = (
-        predict_config.split(":")[0] if ":" in predict_config else predict_config
-    )
+    predict_filename = predict_config.split(":")[0]
 
     if not predict_filename:
         raise CodeLintError("cog.yaml doesn't have a valid predict stanza")
 
+    lint_file(predict_filename)
+
+
+def lint_train():
+    with open("cog.yaml", "r") as f:
+        cog_config = yaml.safe_load(f)
+
+    train_config = cog_config.get("train", "")
+    train_filename = train_config.split(":")[0]
+
+    if not train_filename:
+        raise CodeLintError("cog.yaml doesn't have a valid train stanza")
+
+    lint_file(train_filename)
+
+
+def lint_file(filename: str):
+    if not Path(filename).exists():
+        raise CodeLintError(f"{filename} doesn't exist")
+
     try:
         subprocess.run(
-            ["ruff", "check", predict_filename],
+            ["ruff", "check", filename, "--ignore=E402"],
             check=True,
             capture_output=True,
             text=True,
         )
     except subprocess.CalledProcessError as e:
-        raise CodeLintError(f"Linting failed: {e.stdout}\n{e.stderr}") from e
+        raise CodeLintError(f"Linting {filename} failed: {e.stdout}\n{e.stderr}") from e

--- a/integration_test/fixtures/train/.dockerignore
+++ b/integration_test/fixtures/train/.dockerignore
@@ -1,0 +1,17 @@
+# The .dockerignore file excludes files from the container build process.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude Git files
+.git
+.github
+.gitignore
+
+# Exclude Python cache files
+__pycache__
+.mypy_cache
+.pytest_cache
+.ruff_cache
+
+# Exclude Python virtual environment
+/venv

--- a/integration_test/fixtures/train/cog.yaml
+++ b/integration_test/fixtures/train/cog.yaml
@@ -1,0 +1,29 @@
+# Configuration for Cog ⚙️
+# Reference: https://github.com/replicate/cog/blob/main/docs/yaml.md
+
+build:
+  # set to true if your model requires a GPU
+  gpu: false
+
+  # a list of ubuntu apt packages to install
+  # system_packages:
+  #   - "libgl1-mesa-glx"
+  #   - "libglib2.0-0"
+
+  # python version in the form '3.11' or '3.11.4'
+  python_version: "3.11"
+
+  # a list of packages in the format <package-name>==<version>
+  # python_packages:
+  #   - "numpy==1.19.4"
+  #   - "torch==1.8.0"
+  #   - "torchvision==0.9.0"
+
+  # commands run after the environment is setup
+  # run:
+  #   - "echo env is ready!"
+  #   - "echo another command if needed"
+
+# predict.py defines how predictions are run on your model
+predict: "predict.py:Predictor"
+train: "train.py:train"

--- a/integration_test/fixtures/train/predict.py
+++ b/integration_test/fixtures/train/predict.py
@@ -1,0 +1,23 @@
+import requests
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        self.default_prefix = "hello "
+
+    def predict(
+        self,
+        text: str = Input(description="Text that will be prepended by 'hello '."),
+        replicate_weights: str = Input(
+            description="Trained prefix string.",
+            default=None,
+        ),
+    ) -> str:
+        if replicate_weights:
+            response = requests.get(replicate_weights)
+            prefix = response.text
+        else:
+            prefix = self.default_prefix
+
+        return prefix + text

--- a/integration_test/fixtures/train/train.py
+++ b/integration_test/fixtures/train/train.py
@@ -1,0 +1,13 @@
+from cog import BaseModel, Input, Path
+
+
+class TrainingOutput(BaseModel):
+    weights: Path
+
+
+def train(
+    prefix: str = Input(description="Prefix for inference model"),
+) -> TrainingOutput:
+    output_path = Path("/tmp/out.txt")
+    output_path.write_text(prefix)
+    return TrainingOutput(weights=output_path)

--- a/integration_test/integration_test.py
+++ b/integration_test/integration_test.py
@@ -128,6 +128,47 @@ def test_cog_safe_push_images_with_seed():
         delete_model(model_owner, test_model_name)
 
 
+def test_cog_safe_push_train():
+    model_owner = "replicate-internal"
+    model_name = "test-cog-safe-push-" + datetime.datetime.now().strftime(
+        "%y%m%d-%H%M%S"
+    )
+    test_model_name = model_name + "-test"
+    create_model(model_owner, model_name)
+
+    try:
+        with fixture_dir("train"):
+            cog_safe_push(
+                model_owner,
+                model_name,
+                model_owner,
+                test_model_name,
+                "cpu",
+                train=True,
+                train_destination_owner=model_owner,
+                train_destination_name=test_model_name + "-dest",
+                fuzz_iterations=1,
+            )
+
+        with fixture_dir("train"):
+            cog_safe_push(
+                model_owner,
+                model_name,
+                model_owner,
+                test_model_name,
+                "cpu",
+                train=True,
+                train_destination_owner=model_owner,
+                train_destination_name=test_model_name + "-dest",
+                fuzz_iterations=1,
+            )
+
+    finally:
+        delete_model(model_owner, model_name)
+        delete_model(model_owner, test_model_name)
+        delete_model(model_owner, test_model_name + "-dest")
+
+
 def create_model(model_owner, model_name):
     replicate.models.create(
         owner=model_owner,

--- a/test/test_predict.py
+++ b/test/test_predict.py
@@ -34,6 +34,7 @@ def test_make_predict_inputs_basic(mock_json_object, sample_schemas):
 
     inputs, is_deterministic = make_predict_inputs(
         sample_schemas,
+        train=False,
         only_required=True,
         seed=None,
         fixed_inputs={},
@@ -50,6 +51,7 @@ def test_make_predict_inputs_with_seed(sample_schemas):
 
         inputs, is_deterministic = make_predict_inputs(
             sample_schemas,
+            train=False,
             only_required=True,
             seed=123,
             fixed_inputs={},
@@ -66,6 +68,7 @@ def test_make_predict_inputs_with_fixed_inputs(sample_schemas):
 
         inputs, _ = make_predict_inputs(
             sample_schemas,
+            train=False,
             only_required=True,
             seed=None,
             fixed_inputs={"text": "fixed"},
@@ -86,6 +89,7 @@ def test_make_predict_inputs_with_disabled_inputs(sample_schemas):
 
         inputs, _ = make_predict_inputs(
             sample_schemas,
+            train=False,
             only_required=False,
             seed=None,
             fixed_inputs={},
@@ -106,6 +110,7 @@ def test_make_predict_inputs_with_inputs_history(sample_schemas):
 
         inputs, _ = make_predict_inputs(
             sample_schemas,
+            train=False,
             only_required=True,
             seed=None,
             fixed_inputs={},
@@ -125,6 +130,7 @@ def test_make_predict_inputs_ai_error(sample_schemas):
 
         inputs, _ = make_predict_inputs(
             sample_schemas,
+            train=False,
             only_required=True,
             seed=None,
             fixed_inputs={},
@@ -144,6 +150,7 @@ def test_make_predict_inputs_max_attempts_reached(sample_schemas):
         with pytest.raises(AIError):
             make_predict_inputs(
                 sample_schemas,
+                train=False,
                 only_required=True,
                 seed=None,
                 fixed_inputs={},

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -7,7 +7,7 @@ def test_identical_schemas():
         "Input": {"text": {"type": "string"}, "number": {"type": "integer"}},
         "Output": {"type": "string"},
     }
-    check_backwards_compatible(new, old)  # Should not raise
+    check_backwards_compatible(new, old, train=False)  # Should not raise
 
 
 def test_new_optional_input():
@@ -19,7 +19,7 @@ def test_new_optional_input():
         },
         "Output": {"type": "string"},
     }
-    check_backwards_compatible(new, old)  # Should not raise
+    check_backwards_compatible(new, old, train=False)  # Should not raise
 
 
 def test_removed_input():
@@ -29,7 +29,7 @@ def test_removed_input():
     }
     new = {"Input": {"text": {"type": "string"}}, "Output": {"type": "string"}}
     with pytest.raises(IncompatibleSchema, match="Missing input number"):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_changed_input_type():
@@ -38,7 +38,7 @@ def test_changed_input_type():
     with pytest.raises(
         IncompatibleSchema, match="Input value has changed type from integer to string"
     ):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_added_minimum_constraint():
@@ -50,7 +50,7 @@ def test_added_minimum_constraint():
     with pytest.raises(
         IncompatibleSchema, match="Input value has added a minimum constraint"
     ):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_increased_minimum():
@@ -63,7 +63,7 @@ def test_increased_minimum():
         "Output": {"type": "string"},
     }
     with pytest.raises(IncompatibleSchema, match="Input value has a higher minimum"):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_added_maximum_constraint():
@@ -75,7 +75,7 @@ def test_added_maximum_constraint():
     with pytest.raises(
         IncompatibleSchema, match="Input value has added a maximum constraint"
     ):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_decreased_maximum():
@@ -88,7 +88,7 @@ def test_decreased_maximum():
         "Output": {"type": "string"},
     }
     with pytest.raises(IncompatibleSchema, match="Input value has a lower maximum"):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_changed_choice_type():
@@ -106,7 +106,7 @@ def test_changed_choice_type():
         IncompatibleSchema,
         match="Input choice choices has changed type from string to integer",
     ):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_added_choice():
@@ -120,7 +120,7 @@ def test_added_choice():
         "choice": {"type": "string", "enum": ["A", "B", "C", "D"]},
         "Output": {"type": "string"},
     }
-    check_backwards_compatible(new, old)  # Should not raise
+    check_backwards_compatible(new, old, train=False)  # Should not raise
 
 
 def test_removed_choice():
@@ -137,7 +137,7 @@ def test_removed_choice():
     with pytest.raises(
         IncompatibleSchema, match="Input choice is missing choices: 'C'"
     ):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_new_required_input():
@@ -149,14 +149,14 @@ def test_new_required_input():
     with pytest.raises(
         IncompatibleSchema, match="Input new_required is new and is required"
     ):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_changed_output_type():
     old = {"Input": {}, "Output": {"type": "string"}}
     new = {"Input": {}, "Output": {"type": "integer"}}
     with pytest.raises(IncompatibleSchema, match="Output has changed type"):
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
 
 
 def test_multiple_incompatibilities():
@@ -180,7 +180,7 @@ def test_multiple_incompatibilities():
         "Output": {"type": "integer"},
     }
     with pytest.raises(IncompatibleSchema) as exc_info:
-        check_backwards_compatible(new, old)
+        check_backwards_compatible(new, old, train=False)
     error_message = str(exc_info.value)
     assert "Input text has changed type from string to integer" in error_message
     assert "Input number has a higher minimum" in error_message


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit da27de8003393c881e467e7e91a163288de8f562  | 
|--------|--------|

### Summary:
This PR adds a `--train` argument to test training configurations in Cog models, updates relevant files, and includes integration tests.

**Key points**:
- Add `--train` argument in `cog_safe_push/main.py` for testing training configurations.
- Implement `lint_train` in `cog_safe_push/lint.py` for training configuration linting.
- Update `cog_safe_push/main.py` to handle `train` flag and pass it to `cog_safe_push` function.
- Modify `cog_safe_push/predict.py` to use `replicate.trainings.create` when `train` is true.
- Ensure schema and output checks in `cog_safe_push/schema.py` accommodate training configurations.
- Add integration tests in `integration_test/integration_test.py` for training configurations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->