### PR TITLE
Tighter ruff rules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,14 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements-test.txt
+        pip install .
 
-    - name: Run ruff
+    - name: Lint
       run: |
-        ruff check --ignore=F403,F405
-
-    - name: Run black
-      run: |
-        black --check .
+        ./script/lint
 
   unit-test:
     runs-on: ubuntu-latest
@@ -48,4 +45,4 @@ jobs:
 
     - name: Run pytest
       run: |
-        pytest test/
+        ./script/unit-test

--- a/cog_safe_push/cog.py
+++ b/cog_safe_push/cog.py
@@ -1,11 +1,12 @@
-import subprocess
 import re
-import replicate
+import subprocess
+
+from replicate.model import Model
 
 from . import log
 
 
-def push(model: replicate.model.Model) -> str:
+def push(model: Model) -> str:
     url = f"r8.im/{model.owner}/{model.name}"
     log.info(f"Pushing to {url}")
     process = subprocess.Popen(
@@ -16,6 +17,7 @@ def push(model: replicate.model.Model) -> str:
     )
 
     sha256_id = None
+    assert process.stdout
     for line in process.stdout:
         log.v(line.rstrip())  # Print output in real-time
         if "latest: digest: sha256:" in line:

--- a/cog_safe_push/exceptions.py
+++ b/cog_safe_push/exceptions.py
@@ -6,11 +6,11 @@ class SchemaLintError(Exception):
     pass
 
 
-class IncompatibleSchema(Exception):
+class IncompatibleSchemaError(Exception):
     pass
 
 
-class OutputsDontMatch(Exception):
+class OutputsDontMatchError(Exception):
     pass
 
 
@@ -18,11 +18,11 @@ class FuzzError(Exception):
     pass
 
 
-class PredictionTimeout(Exception):
+class PredictionTimeoutError(Exception):
     pass
 
 
-class PredictionFailed(Exception):
+class PredictionFailedError(Exception):
     pass
 
 

--- a/cog_safe_push/lint.py
+++ b/cog_safe_push/lint.py
@@ -1,14 +1,14 @@
-from pathlib import Path
 import subprocess
+from pathlib import Path
+from typing import Any
+
 import yaml
 
 from .exceptions import CodeLintError
 
 
 def lint_predict():
-    with open("cog.yaml", "r") as f:
-        cog_config = yaml.safe_load(f)
-
+    cog_config = load_cog_config()
     predict_config = cog_config.get("predict", "")
     predict_filename = predict_config.split(":")[0]
 
@@ -19,9 +19,7 @@ def lint_predict():
 
 
 def lint_train():
-    with open("cog.yaml", "r") as f:
-        cog_config = yaml.safe_load(f)
-
+    cog_config = load_cog_config()
     train_config = cog_config.get("train", "")
     train_filename = train_config.split(":")[0]
 
@@ -29,6 +27,11 @@ def lint_train():
         raise CodeLintError("cog.yaml doesn't have a valid train stanza")
 
     lint_file(train_filename)
+
+
+def load_cog_config() -> dict[str, Any]:
+    with Path("cog.yaml").open() as f:
+        return yaml.safe_load(f)
 
 
 def lint_file(filename: str):

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -1,10 +1,12 @@
-from collections import defaultdict
-import re
 import argparse
-import replicate
-from replicate.exceptions import ReplicateException
+import re
+from collections import defaultdict
 
-from . import cog, lint, schema, predict, log
+import replicate
+from replicate.exceptions import ReplicateError
+from replicate.model import Model
+
+from . import cog, lint, log, predict, schema
 
 
 def main():
@@ -244,8 +246,7 @@ def parse_inputs(inputs_list: list[str]) -> dict[str, list[predict.WeightedInput
         except ValueError:
             raise ValueError(f"Invalid input format: {input_str}")
 
-    inputs = make_weighted_inputs(input_values, input_weights)
-    return inputs
+    return make_weighted_inputs(input_values, input_weights)
 
 
 def make_weighted_inputs(
@@ -310,7 +311,7 @@ def parse_input_weight_percent(value_str: str) -> tuple[str, float | None]:
     return value_str, None
 
 
-def get_or_create_model(model_owner, model_name, hardware) -> replicate.model.Model:
+def get_or_create_model(model_owner, model_name, hardware) -> Model:
     model = get_model(model_owner, model_name)
 
     if not model:
@@ -329,10 +330,10 @@ def get_or_create_model(model_owner, model_name, hardware) -> replicate.model.Mo
     return model
 
 
-def get_model(owner, name) -> replicate.model.Model:
+def get_model(owner, name) -> Model | None:
     try:
         model = replicate.models.get(f"{owner}/{name}")
-    except ReplicateException as e:
+    except ReplicateError as e:
         if e.status == 404:
             return None
         raise

--- a/cog_safe_push/retry.py
+++ b/cog_safe_push/retry.py
@@ -17,6 +17,7 @@ def retry(attempts=3):
                     else:
                         log.warning(f"Giving up after {attempts} attempts")
                         raise
+            return None
 
         return wrapper_retry
 

--- a/cog_safe_push/schema.py
+++ b/cog_safe_push/schema.py
@@ -1,9 +1,9 @@
-import replicate
+from replicate.model import Model
 
-from .exceptions import IncompatibleSchema, SchemaLintError
+from .exceptions import IncompatibleSchemaError, SchemaLintError
 
 
-def lint(model: replicate.model.Model, train: bool):
+def lint(model: Model, train: bool):
     errors = []
 
     input_name = "TrainingInput" if train else "Input"
@@ -98,7 +98,7 @@ def check_backwards_compatible(
         errors.append(f"{output_name} has changed type")
 
     if errors:
-        raise IncompatibleSchema(
+        raise IncompatibleSchemaError(
             "Schema is not backwards compatible: \n"
             + "\n".join(["* " + e for e in errors])
         )

--- a/integration_test/fixtures/image-base-seed/predict.py
+++ b/integration_test/fixtures/image-base-seed/predict.py
@@ -1,8 +1,9 @@
+import math
 import os
 import random
-import math
-from PIL import Image, ImageDraw
+
 from cog import BasePredictor, Input, Path
+from PIL import Image, ImageDraw
 
 
 class Predictor(BasePredictor):

--- a/integration_test/fixtures/image-base/predict.py
+++ b/integration_test/fixtures/image-base/predict.py
@@ -1,8 +1,8 @@
 # Prediction interface for Cog ⚙️
 # https://github.com/replicate/cog/blob/main/docs/python.md
 
-from PIL import Image
 from cog import BasePredictor, Input, Path
+from PIL import Image
 
 
 class Predictor(BasePredictor):

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,56 @@
+{
+  "include": [
+    "."
+  ],
+
+  "exclude": [
+    "**/node_modules",
+    "**/__pycache__",
+    "integration_test/fixtures",
+  ],
+
+  "ignore": [
+    "src/oldstuff"
+  ],
+
+  "defineConstant": {
+    "DEBUG": true
+  },
+
+  "stubPath": "src/stubs",
+
+  "reportMissingImports": "error",
+  "reportMissingTypeStubs": false,
+
+  "pythonVersion": "3.11",
+  "pythonPlatform": "Linux",
+
+  "executionEnvironments": [
+    {
+      "root": "src/web",
+      "pythonVersion": "3.5",
+      "pythonPlatform": "Windows",
+      "extraPaths": [
+        "src/service_libs"
+      ],
+      "reportMissingImports": "warning"
+    },
+    {
+      "root": "src/sdk",
+      "pythonVersion": "3.0",
+      "extraPaths": [
+        "src/backend"
+      ]
+    },
+    {
+      "root": "src/tests",
+      "extraPaths": [
+        "src/tests/e2e",
+        "src/sdk"
+      ]
+    },
+    {
+      "root": "src"
+    }
+  ]
+}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest
-black
 ruff
+pyright

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,77 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F", "W", "I", "N", "UP", "A", "ICN", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "ARG", "PTH", "ERA", "FLY"]
+ignore = ["F403", "F405", "PT011", "SIM117", "SIM102", "ERA001", "RSE102"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/script/integration-test
+++ b/script/integration-test
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+
+pytest integration_test/

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+
+ruff check
+ruff format --check
+pyright

--- a/script/unit-test
+++ b/script/unit-test
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+
+pytest test/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-from setuptools import setup, find_packages
+from pathlib import Path
+
+from setuptools import find_packages, setup
 
 setup(
     name="cog-safe-push",
@@ -18,8 +20,8 @@ setup(
     author="Andreas Jansson",
     author_email="andreas@replicate.com",
     description="Safely push a Cog model, with tests",
-    # long_description=open("README.md").read(),
-    # long_description_content_type="text/markdown",
+    long_description=Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     url="https://github.com/andreasjansson/cog-safe-push",
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,12 +1,13 @@
 import pytest
+
 from cog_safe_push.main import (
-    parse_model,
-    parse_inputs,
+    make_weighted_inputs,
     parse_input_value,
     parse_input_weight_percent,
-    make_weighted_inputs,
+    parse_inputs,
+    parse_model,
 )
-from cog_safe_push.predict import WeightedInputValue, OMITTED_INPUT
+from cog_safe_push.predict import OMITTED_INPUT, WeightedInputValue
 
 
 def test_parse_model():

--- a/test/test_predict.py
+++ b/test/test_predict.py
@@ -1,7 +1,9 @@
-import pytest
 from unittest.mock import patch
-from cog_safe_push.predict import make_predict_inputs
+
+import pytest
+
 from cog_safe_push.exceptions import AIError
+from cog_safe_push.predict import make_predict_inputs
 
 
 @pytest.fixture
@@ -118,7 +120,8 @@ def test_make_predict_inputs_with_inputs_history(sample_schemas):
             inputs_history=inputs_history,
         )
 
-        assert inputs != inputs_history[0] and inputs != inputs_history[1]
+        assert inputs != inputs_history[0]
+        assert inputs != inputs_history[1]
 
 
 def test_make_predict_inputs_ai_error(sample_schemas):

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,5 +1,6 @@
 import pytest
-from cog_safe_push.schema import check_backwards_compatible, IncompatibleSchema
+
+from cog_safe_push.schema import IncompatibleSchemaError, check_backwards_compatible
 
 
 def test_identical_schemas():
@@ -28,7 +29,7 @@ def test_removed_input():
         "Output": {"type": "string"},
     }
     new = {"Input": {"text": {"type": "string"}}, "Output": {"type": "string"}}
-    with pytest.raises(IncompatibleSchema, match="Missing input number"):
+    with pytest.raises(IncompatibleSchemaError, match="Missing input number"):
         check_backwards_compatible(new, old, train=False)
 
 
@@ -36,7 +37,8 @@ def test_changed_input_type():
     old = {"Input": {"value": {"type": "integer"}}, "Output": {"type": "string"}}
     new = {"Input": {"value": {"type": "string"}}, "Output": {"type": "string"}}
     with pytest.raises(
-        IncompatibleSchema, match="Input value has changed type from integer to string"
+        IncompatibleSchemaError,
+        match="Input value has changed type from integer to string",
     ):
         check_backwards_compatible(new, old, train=False)
 
@@ -48,7 +50,7 @@ def test_added_minimum_constraint():
         "Output": {"type": "string"},
     }
     with pytest.raises(
-        IncompatibleSchema, match="Input value has added a minimum constraint"
+        IncompatibleSchemaError, match="Input value has added a minimum constraint"
     ):
         check_backwards_compatible(new, old, train=False)
 
@@ -62,7 +64,9 @@ def test_increased_minimum():
         "Input": {"value": {"type": "integer", "minimum": 1}},
         "Output": {"type": "string"},
     }
-    with pytest.raises(IncompatibleSchema, match="Input value has a higher minimum"):
+    with pytest.raises(
+        IncompatibleSchemaError, match="Input value has a higher minimum"
+    ):
         check_backwards_compatible(new, old, train=False)
 
 
@@ -73,7 +77,7 @@ def test_added_maximum_constraint():
         "Output": {"type": "string"},
     }
     with pytest.raises(
-        IncompatibleSchema, match="Input value has added a maximum constraint"
+        IncompatibleSchemaError, match="Input value has added a maximum constraint"
     ):
         check_backwards_compatible(new, old, train=False)
 
@@ -87,7 +91,9 @@ def test_decreased_maximum():
         "Input": {"value": {"type": "integer", "maximum": 99}},
         "Output": {"type": "string"},
     }
-    with pytest.raises(IncompatibleSchema, match="Input value has a lower maximum"):
+    with pytest.raises(
+        IncompatibleSchemaError, match="Input value has a lower maximum"
+    ):
         check_backwards_compatible(new, old, train=False)
 
 
@@ -103,7 +109,7 @@ def test_changed_choice_type():
         "Output": {"type": "string"},
     }
     with pytest.raises(
-        IncompatibleSchema,
+        IncompatibleSchemaError,
         match="Input choice choices has changed type from string to integer",
     ):
         check_backwards_compatible(new, old, train=False)
@@ -135,7 +141,7 @@ def test_removed_choice():
         "Output": {"type": "string"},
     }
     with pytest.raises(
-        IncompatibleSchema, match="Input choice is missing choices: 'C'"
+        IncompatibleSchemaError, match="Input choice is missing choices: 'C'"
     ):
         check_backwards_compatible(new, old, train=False)
 
@@ -147,7 +153,7 @@ def test_new_required_input():
         "Output": {"type": "string"},
     }
     with pytest.raises(
-        IncompatibleSchema, match="Input new_required is new and is required"
+        IncompatibleSchemaError, match="Input new_required is new and is required"
     ):
         check_backwards_compatible(new, old, train=False)
 
@@ -155,7 +161,7 @@ def test_new_required_input():
 def test_changed_output_type():
     old = {"Input": {}, "Output": {"type": "string"}}
     new = {"Input": {}, "Output": {"type": "integer"}}
-    with pytest.raises(IncompatibleSchema, match="Output has changed type"):
+    with pytest.raises(IncompatibleSchemaError, match="Output has changed type"):
         check_backwards_compatible(new, old, train=False)
 
 
@@ -179,7 +185,7 @@ def test_multiple_incompatibilities():
         "choice": {"type": "string", "enum": ["A", "B"]},
         "Output": {"type": "integer"},
     }
-    with pytest.raises(IncompatibleSchema) as exc_info:
+    with pytest.raises(IncompatibleSchemaError) as exc_info:
         check_backwards_compatible(new, old, train=False)
     error_message = str(exc_info.value)
     assert "Input text has changed type from string to integer" in error_message


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 795779ba051bffc295032850520d535aecf70d4f  | 
|--------|--------|

### Summary:
Switch from Black to Ruff for linting, update CI workflows to include Pyright, and refactor code for consistency in `cog_safe_push`.

**Key points**:
- Switch from Black to Ruff for linting and formatting.
- Update `.github/workflows/ci.yaml` to use Ruff and Pyright.
- Refactor import statements in `cog_safe_push/ai.py`, `cog_safe_push/cog.py`, `cog_safe_push/lint.py` for consistency.
- Rename exception classes in `cog_safe_push/exceptions.py` for consistency.
- Add `ruff.toml` for Ruff configuration.
- Modify `requirements-test.txt` to remove Black and add Pyright.
- Adjust test files to comply with new Ruff linting rules.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->