### PR TITLE
Fix AttributeError in download function by using Path.unlink()

### DIFF
--- a/cog_safe_push/predict.py
+++ b/cog_safe_push/predict.py
@@ -572,11 +572,12 @@ def download(url: str) -> Iterator[Path]:
         response.raise_for_status()
         tmp_file.write(response.content)
         tmp_file.flush()
+        tmp_path = Path(tmp_file.name)
 
     try:
-        yield Path(tmp_file.name)
+        yield tmp_path
     finally:
-        tmp_file.unlink()
+        tmp_path.unlink(missing_ok=True)
 
 
 def truncate(s, max_length=500) -> str:


### PR DESCRIPTION
<img width="806" alt="image" src="https://github.com/user-attachments/assets/8dc77078-2cac-495a-a671-65fa68a219a5">

I found a bug in our `download` function in `predict.py`. The error looked like this:

```
AttributeError: '_io.BufferedRandom' object has no attribute 'unlink'
```

The problem was that we were trying to use `unlink()` on a file object, but file objects don't have this method. Only `Path` objects have `unlink()`.

To fix this, I made a few small changes:

1. I created a `Path` object from the file name:
   ```python
   tmp_path = Path(tmp_file.name)
   ```

2. I used this `Path` object instead of making a new one each time:
   ```python
   yield tmp_path
   ```

3. I called `unlink()` on the `Path` object, not the file object:
   ```python
   tmp_path.unlink(missing_ok=True)
   ```

These changes make sure we're using `unlink()` on the right kind of object. I also added `missing_ok=True` just in case the file is already gone when we try to delete it.

This fix should stop the error from happening while keeping the function working the same way it did before.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0e69638313f5182f06b6ca6acd5131d350c1e2c0  | 
|--------|--------|

### Summary:
Fix `AttributeError` in `cog_safe_push/predict.py` `download` function by using `Path.unlink()` correctly.

**Key points**:
- Fix `AttributeError` in `cog_safe_push/predict.py` `download` function.
- Create `Path` object from `tmp_file.name`.
- Use `tmp_path` for `yield` and `unlink()`.
- Add `missing_ok=True` to `unlink()` to handle missing files.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->