### PR TITLE
validate yaml for forbidden extra fields

### DIFF
--- a/cog_safe_push/config.py
+++ b/cog_safe_push/config.py
@@ -1,6 +1,6 @@
 import argparse
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from .exceptions import ArgumentError
 
@@ -11,6 +11,8 @@ InputScalar = bool | int | float | str | list[int] | list[str] | list[float]
 
 
 class TestCase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     inputs: dict[str, InputScalar]
     exact_string: str | None = None
     match_url: str | None = None
@@ -30,6 +32,8 @@ class TestCase(BaseModel):
 
 
 class FuzzConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     fixed_inputs: dict[str, InputScalar] = {}
     disabled_inputs: list[str] = []
     duration: int = DEFAULT_FUZZ_DURATION
@@ -37,6 +41,8 @@ class FuzzConfig(BaseModel):
 
 
 class PredictConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     compare_outputs: bool = True
     predict_timeout: int = DEFAULT_PREDICT_TIMEOUT
     test_cases: list[TestCase] = []
@@ -44,6 +50,8 @@ class PredictConfig(BaseModel):
 
 
 class TrainConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     destination: str | None = None
     destination_hardware: str = "cpu"
     train_timeout: int = DEFAULT_PREDICT_TIMEOUT
@@ -52,6 +60,8 @@ class TrainConfig(BaseModel):
 
 
 class Config(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     model: str
     test_model: str | None = None
     test_hardware: str = "cpu"

--- a/cog_safe_push/predict.py
+++ b/cog_safe_push/predict.py
@@ -339,6 +339,8 @@ def predict(
             version=model.versions.list()[0].id, input=inputs
         )
 
+    log.vv(f"Prediction URL: https://replicate.com/p/{prediction.id}")
+
     start_time = time.time()
     while prediction.status not in ["succeeded", "failed", "canceled"]:
         time.sleep(0.5)


### PR DESCRIPTION
also small optimization to reuse test model instead of repushing if both train and predict are set.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 726a1b3fa6ba12a0b3ed50d306757f357053554e  | 
|--------|--------|

### Summary:
This PR forbids extra fields in YAML configurations and optimizes model reuse to avoid redundant pushes, with added logging for prediction URLs.

**Key points**:
- Added `ConfigDict(extra="forbid")` to `TestCase`, `FuzzConfig`, `PredictConfig`, `TrainConfig`, and `Config` classes in `cog_safe_push/config.py` to forbid extra fields in YAML.
- Optimized model reuse in `cog_safe_push/main.py` by introducing `reuse_test_model` to avoid redundant pushes when both train and predict are set.
- Updated `cog_safe_push` function to handle `reuse_test_model` parameter.
- Added logging of prediction URL in `cog_safe_push/predict.py` for better traceability.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->