### PR TITLE
proper config for train + predict

### DIFF
--- a/cog_safe_push/config.py
+++ b/cog_safe_push/config.py
@@ -1,5 +1,5 @@
-import sys
 import argparse
+import sys
 
 from pydantic import BaseModel, ConfigDict, model_validator
 

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -235,7 +235,7 @@ def run_config(config: Config, no_push: bool):
             test_model_name=test_model_name,
             test_hardware=config.test_hardware,
             dockerfile=config.dockerfile,
-            train=False
+            train=False,
         )
         cog_safe_push(
             task_context=task_context,

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -227,16 +227,16 @@ def run_config(config: Config, no_push: bool):
             fuzz = config.predict.fuzz
         else:
             fuzz = FuzzConfig(fixed_inputs={}, disabled_inputs=[], iterations=0)
-        if task_context is None:  # has not been created in the training block above
-            task_context = make_task_context(
-                model_owner=model_owner,
-                model_name=model_name,
-                test_model_owner=test_model_owner,
-                test_model_name=test_model_name,
-                test_hardware=config.test_hardware,
-                dockerfile=config.dockerfile,
-            )
-
+        # regenerating config w/out training set
+        task_context = make_task_context(
+            model_owner=model_owner,
+            model_name=model_name,
+            test_model_owner=test_model_owner,
+            test_model_name=test_model_name,
+            test_hardware=config.test_hardware,
+            dockerfile=config.dockerfile,
+            train=False
+        )
         cog_safe_push(
             task_context=task_context,
             no_push=no_push,

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -236,6 +236,7 @@ def run_config(config: Config, no_push: bool):
             test_hardware=config.test_hardware,
             dockerfile=config.dockerfile,
             train=False,
+            push_test_model=config.train is None,
         )
         cog_safe_push(
             task_context=task_context,

--- a/cog_safe_push/task_context.py
+++ b/cog_safe_push/task_context.py
@@ -67,9 +67,9 @@ def make_task_context(
     pushed_version_id = cog.push(test_model, dockerfile)
     test_model.reload()
     try:
-        assert (
-            test_model.versions.list()[0].id == pushed_version_id
-        ), f"Pushed version ID {pushed_version_id} doesn't match latest version on {test_model_owner}/{test_model_name}: {test_model.versions.list()[0].id}"
+        assert test_model.versions.list()[0].id == pushed_version_id, (
+            f"Pushed version ID {pushed_version_id} doesn't match latest version on {test_model_owner}/{test_model_name}: {test_model.versions.list()[0].id}"
+        )
     except ReplicateError as e:
         if e.status == 404:
             # Assume it's an official model

--- a/end-to-end-test/test_end_to_end.py
+++ b/end-to-end-test/test_end_to_end.py
@@ -217,6 +217,7 @@ def test_cog_safe_push_train():
                     train_destination_name=test_model_name + "-dest",
                 ),
                 fuzz_iterations=1,
+                do_compare_outputs=False,
             )
 
     finally:


### PR DESCRIPTION
The current way that cog-safe-push is set up for configs w/train and predict means that the tool will call `train` for predictions instead of `predict`. This will fail! see [here](https://github.com/replicate/flux-fine-tuner/actions/runs/12934720646/job/36076381721) for an example. 

Root cause here is b/c if `task_context` already exists from safe-pushing a training, we just reuse it. BUT - `task_context` has an `is_train` function that's set to True in the initial training step, and the `RunTestCase` keys off `task_context` to determine whether it should run a training or a prediction - meaning that if we reuse `task_context`, we run a training. 

`TaskContext` is immutable, so let's just generate a new one without predictions configured & add a flag so we don't push the model twice. 


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `cog-safe-push` to correctly use `predict` instead of `train` by regenerating `task_context` and adding a flag to prevent double model pushing.
> 
>   - **Behavior**:
>     - Fixes issue where `cog-safe-push` calls `train` instead of `predict` by regenerating `task_context` without training configurations in `run_config()` in `main.py`.
>     - Adds `push_test_model` flag to `make_task_context()` in `task_context.py` to prevent double model pushing.
>   - **Tests**:
>     - Updates `test_cog_safe_push_train()` in `test_end_to_end.py` to set `do_compare_outputs=False` for prediction tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fcog-safe-push&utm_source=github&utm_medium=referral)<sup> for 82b6c5c63274de97aee0daab6876111cc9fc1382. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->