### PR TITLE
Output checkers refactor + error_contains checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,15 +172,19 @@ predict:
     fixed_inputs: {}
   predict_timeout: 300
   test_cases:
-  - exact_string: <exact string match>
-    inputs:
+  - inputs:
       <input1>: <value1>
+    exact_string: <exact string match>
   - inputs:
       <input2>: <value2>
     match_url: <match output image against url>
   - inputs:
       <input3>: <value3>
     match_prompt: <match output using AI prompt, e.g. 'an image of a cat'>
+  - inputs:
+      <input4>: <value4>
+    error_contains: <assert error and that the error message contains a string>
+
 test_hardware: <hardware, e.g. cpu>
 test_model: <test model, or empty to append '-test' to model>
 train:
@@ -192,15 +196,18 @@ train:
     iterations: 10
     fixed_inputs: {}
   test_cases:
-  - exact_string: <exact string match>
-    inputs:
+  - inputs:
       <input1>: <value1>
+    exact_string: <exact string match>
   - inputs:
       <input2>: <value2>
     match_url: <match output image against url>
   - inputs:
       <input3>: <value3>
     match_prompt: <match output using AI prompt, e.g. 'an image of a cat'>
+  - inputs:
+      <input4>: <value4>
+    error_contains: <assert error and that the error message contains a string>
   train_timeout: 300
 
 # values between < and > should be edited

--- a/cog_safe_push/config.py
+++ b/cog_safe_push/config.py
@@ -18,16 +18,17 @@ class TestCase(BaseModel):
     exact_string: str | None = None
     match_url: str | None = None
     match_prompt: str | None = None
+    error_contains: str | None = None
 
     @model_validator(mode="after")
     def check_mutually_exclusive(self):
         set_fields = sum(
             getattr(self, field) is not None
-            for field in ["exact_string", "match_url", "match_prompt"]
+            for field in ["exact_string", "match_url", "match_prompt", "error_contains"]
         )
         if set_fields > 1:
             raise ArgumentError(
-                "At most one of 'exact_string', 'match_url', or 'match_prompt' must be set"
+                "At most one of 'exact_string', 'match_url', 'match_prompt', or 'error_contains' must be set"
             )
         return self
 

--- a/cog_safe_push/exceptions.py
+++ b/cog_safe_push/exceptions.py
@@ -30,12 +30,11 @@ class PredictionTimeoutError(CogSafePushError):
     pass
 
 
-class PredictionFailedError(CogSafePushError):
-    pass
-
-
 class TestCaseFailedError(CogSafePushError):
-    pass
+    __test__ = False
+
+    def __init__(self, message):
+        super().__init__(f"Test case failed: {message}")
 
 
 class AIError(Exception):

--- a/cog_safe_push/log.py
+++ b/cog_safe_push/log.py
@@ -42,11 +42,11 @@ def vvv(message):
 
 def set_verbosity(verbosity):
     global level
-    if verbosity == 0:
+    if verbosity <= 0:
         level = INFO
     if verbosity == 1:
         level = VERBOSE1
     if verbosity == 2:
         level = VERBOSE2
-    if verbosity == 3:
+    if verbosity >= 3:
         level = VERBOSE3

--- a/cog_safe_push/output_checkers.py
+++ b/cog_safe_push/output_checkers.py
@@ -1,0 +1,100 @@
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from . import log
+from .exceptions import (
+    AIError,
+    TestCaseFailedError,
+)
+from .match_outputs import is_url, output_matches_prompt, urls_match
+from .utils import truncate
+
+
+class OutputChecker(Protocol):
+    async def __call__(self, output: Any | None, error: str | None) -> None: ...
+
+
+@dataclass
+class NoChecker(OutputChecker):
+    async def __call__(self, _: Any | None, error: str | None) -> None:
+        check_no_error(error)
+
+
+@dataclass
+class ExactStringChecker(OutputChecker):
+    string: str
+
+    async def __call__(self, output: Any | None, error: str | None) -> None:
+        check_no_error(error)
+
+        if not isinstance(output, str):
+            raise TestCaseFailedError(f"Expected string, got {truncate(output, 200)}")
+
+        if output != self.string:
+            raise TestCaseFailedError(
+                f"Expected '{self.string}', got '{truncate(output, 200)}'"
+            )
+
+
+@dataclass
+class MatchURLChecker(OutputChecker):
+    url: str
+
+    async def __call__(self, output: Any | None, error: str | None) -> None:
+        check_no_error(error)
+
+        output_url = None
+        if isinstance(output, str) and is_url(output):
+            output_url = output
+        if (
+            isinstance(output, list)
+            and len(output) == 1
+            and isinstance(output[0], str)
+            and is_url(output[0])
+        ):
+            output_url = output[0]
+        if output_url is not None:
+            matches, error = await urls_match(
+                self.url, output_url, is_deterministic=True
+            )
+            if not matches:
+                raise TestCaseFailedError(
+                    f"File at URL {self.url} does not match file at URL {output_url}. {error}"
+                )
+            log.info(f"File at URL {self.url} matched file at URL {output_url}")
+        else:
+            raise TestCaseFailedError(f"Expected URL, got '{truncate(output, 200)}'")
+
+
+@dataclass
+class AIChecker(OutputChecker):
+    prompt: str
+
+    async def __call__(self, output: Any | None, error: str | None) -> None:
+        check_no_error(error)
+
+        try:
+            matches, error = await output_matches_prompt(output, self.prompt)
+            if not matches:
+                raise TestCaseFailedError(error)
+        except AIError as e:
+            raise TestCaseFailedError(f"AI error: {str(e)}")
+
+
+@dataclass
+class ErrorContainsChecker(OutputChecker):
+    string: str
+
+    async def __call__(self, _: Any | None, error: str | None) -> None:
+        if error is None:
+            raise TestCaseFailedError("Expected error, prediction succeeded")
+
+        if self.string not in error:
+            raise TestCaseFailedError(
+                f"Expected error to contain {self.string}, got {error}"
+            )
+
+
+def check_no_error(error: str | None) -> None:
+    if error is not None:
+        raise TestCaseFailedError(f"Prediction raised unexpected error: {error}")

--- a/cog_safe_push/utils.py
+++ b/cog_safe_push/utils.py
@@ -1,0 +1,5 @@
+def truncate(s, max_length=500) -> str:
+    s = str(s)
+    if len(s) <= max_length:
+        return s
+    return s[:max_length] + "..."

--- a/script/end-to-end-test
+++ b/script/end-to-end-test
@@ -1,3 +1,3 @@
 #!/bin/bash -eu
 
-pytest -n4 -s -v end-to-end-test/
+pytest -n4 -s -v end-to-end-test/ $@


### PR DESCRIPTION
This PR makes it possible to assert that a test case throws an error, with a specific error message.

For example:

```yaml
model: my-user/my-model
predict:
  test_cases:
    - inputs:
        text: this should throw an error
      error_contains: error!
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `error_contains` checker for specific error message assertions and refactor output checkers into `output_checkers.py`.
> 
>   - **Behavior**:
>     - Add `error_contains` to `TestCase` in `config.py` to assert specific error messages.
>     - Refactor output checking logic into `output_checkers.py` with `ErrorContainsChecker`, `ExactStringChecker`, `MatchURLChecker`, `AIChecker`, and `NoChecker`.
>     - Update `predict()` in `predict.py` to return both output and error.
>   - **Main Logic**:
>     - Modify `cog_safe_push()` in `main.py` to use `OutputChecker` for test cases.
>     - Update `RunTestCase` in `tasks.py` to utilize `OutputChecker`.
>   - **Documentation**:
>     - Update `README.md` to include `error_contains` in test case examples.
>   - **Tests**:
>     - Add test cases in `test_end_to_end.py` to verify `error_contains` functionality.
>   - **Misc**:
>     - Adjust verbosity handling in `log.py` to use `<=` and `>=` for boundary checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fcog-safe-push&utm_source=github&utm_medium=referral)<sup> for ebad265089c6c357bfe8b0ebfe6925ed6c02ebb5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->