### PR TITLE
Add support for extracting SHA256 from version

### DIFF
--- a/cog_safe_push/cog.py
+++ b/cog_safe_push/cog.py
@@ -29,6 +29,11 @@ def push(model: Model, dockerfile: str | None, fast_push: bool = False) -> str:
             match = re.search(r"sha256:([a-f0-9]{64})", line)
             if match:
                 sha256_id = match.group(1)
+        # In the case of fast push, we get the version from the identifier printed to stdout
+        elif "New Version:" in line:
+            potential_sha256_id = line.split(":")[-1]
+            if bool(re.match(r"^[a-f0-9]{64}$", potential_sha256_id)):
+                sha256_id = potential_sha256_id
 
     process.wait()
 


### PR DESCRIPTION
* Fast push doesn’t docker push and expresses the resulting SHA256 for the version in a different
way
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support in `push()` for extracting SHA256 from `fast_push` output in `cog.py`.
> 
>   - **Behavior**:
>     - In `push()` in `cog.py`, adds support for extracting SHA256 from `fast_push` output by checking for "New Version:" line and validating SHA256 format.
>   - **Error Handling**:
>     - Raises `ValueError` if no SHA256 ID is found in the output.
>     - Raises `subprocess.CalledProcessError` if the process return code is non-zero.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fcog-safe-push&utm_source=github&utm_medium=referral)<sup> for 2acc5fefdfa56786ef2ff2bfcd5d70c0ded8186a. You can [customize](https://app.ellipsis.dev/replicate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->