### PR TITLE
Allow ignoring of schema conflicts

### DIFF
--- a/cog_safe_push/config.py
+++ b/cog_safe_push/config.py
@@ -79,6 +79,7 @@ class Config(BaseModel):
     dockerfile: str | None = None
     parallel: int = 4
     fast_push: bool = False
+    ignore_schema_compatibility: bool = False
 
     def override(self, field: str, args: argparse.Namespace, arg: str):
         if hasattr(args, arg) and getattr(args, arg) is not None:

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -323,7 +323,7 @@ def cog_safe_push(
         test_model_schemas = schema.get_schemas(task_context.test_model, train=train)
         model_schemas = schema.get_schemas(task_context.model, train=train)
         try:
-            schema.check_backwards_compatible(test_model_schemas, model_schemas, train)
+            schema.check_backwards_compatible(test_model_schemas, model_schemas, train=train)
         except IncompatibleSchemaError as e:
             if ignore_schema_compatibility:
                 log.warning(f"Ignoring schema compatibility error: {e}")

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -323,7 +323,9 @@ def cog_safe_push(
         test_model_schemas = schema.get_schemas(task_context.test_model, train=train)
         model_schemas = schema.get_schemas(task_context.model, train=train)
         try:
-            schema.check_backwards_compatible(test_model_schemas, model_schemas, train=train)
+            schema.check_backwards_compatible(
+                test_model_schemas, model_schemas, train=train
+            )
         except IncompatibleSchemaError as e:
             if ignore_schema_compatibility:
                 log.warning(f"Ignoring schema compatibility error: {e}")

--- a/end-to-end-test/test_end_to_end.py
+++ b/end-to-end-test/test_end_to_end.py
@@ -71,6 +71,14 @@ def test_cog_safe_push():
                     )
                 )
 
+        with fixture_dir("incompatible-schema"):
+            cog_safe_push(
+                make_task_context(
+                    model_owner, model_name, model_owner, test_model_name, "cpu"
+                ),
+                ignore_schema_compatibility=True,
+            )
+
         with fixture_dir("outputs-dont-match"):
             with pytest.raises(OutputsDontMatchError):
                 cog_safe_push(

--- a/end-to-end-test/test_end_to_end.py
+++ b/end-to-end-test/test_end_to_end.py
@@ -77,6 +77,7 @@ def test_cog_safe_push():
                     model_owner, model_name, model_owner, test_model_name, "cpu"
                 ),
                 ignore_schema_compatibility=True,
+                do_compare_outputs=False,
             )
 
         with fixture_dir("outputs-dont-match"):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -127,6 +127,7 @@ def test_parse_config_file(tmp_path, monkeypatch):
     model: user/model
     test_model: user/test-model
     test_hardware: gpu
+    ignore_schema_compatibility: true
     predict:
       compare_outputs: false
       predict_timeout: 500
@@ -150,6 +151,7 @@ def test_parse_config_file(tmp_path, monkeypatch):
     assert config.model == "user/model"
     assert config.test_model == "user/test-model"
     assert config.test_hardware == "gpu"
+    assert config.ignore_schema_compatibility is True
     assert config.predict is not None
     assert config.predict.fuzz is not None
     assert not config.predict.compare_outputs
@@ -379,6 +381,14 @@ def test_parse_config_missing_fuzz_section(tmp_path, monkeypatch):
 
     with pytest.raises(ArgumentError, match="missing a predict.fuzz section"):
         parse_args_and_config()
+
+
+def test_parse_args_ignore_schema_compatibility(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv", ["cog-safe-push", "user/model", "--ignore-schema-compatibility"]
+    )
+    config, _ = parse_args_and_config()
+    assert config.ignore_schema_compatibility is True
 
 
 def test_parse_model():


### PR DESCRIPTION
Sometimes a conflict is necessary, allow an override
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `ignore_schema_compatibility` option to allow ignoring schema compatibility errors during model push.
> 
>   - **Behavior**:
>     - Adds `ignore_schema_compatibility` option to `Config` in `config.py` to allow ignoring schema compatibility errors.
>     - Updates `parse_args_and_config()` in `main.py` to parse `--ignore-schema-compatibility` argument.
>     - Modifies `cog_safe_push()` in `main.py` to handle `IncompatibleSchemaError` based on `ignore_schema_compatibility` flag.
>   - **Tests**:
>     - Adds `test_cog_safe_push_ignore_incompatible_schema()` in `test_end_to_end.py` to test ignoring schema compatibility.
>     - Adds `test_parse_args_ignore_schema_compatibility()` in `test_main.py` to test argument parsing.
>     - Updates `test_parse_config_file()` in `test_main.py` to check config file parsing for `ignore_schema_compatibility`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fcog-safe-push&utm_source=github&utm_medium=referral)<sup> for eb248c5d14a45683426486c2aae27ce1a6b94d30. You can [customize](https://app.ellipsis.dev/replicate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->