### PR TITLE
Add creation and pushing of official models

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,105 +264,60 @@ You can use a configuration file instead of passing all arguments on the command
 # cog-safe-push --help-config
 
 model: <model>
-parallel: 4
+test_model: <test model, or empty to append '-test' to model>
+test_hardware: <hardware, e.g. cpu>
 predict:
   compare_outputs: true
-  fuzz:
-    disabled_inputs: []
-    fixed_inputs: {}
-    iterations: 10
   predict_timeout: 300
   test_cases:
-  - exact_string: <exact string match>
-    inputs:
+  - inputs:
       <input1>: <value1>
+    exact_string: <exact string match>
   - inputs:
       <input2>: <value2>
     match_url: <match output image against url>
   - inputs:
       <input3>: <value3>
     match_prompt: <match output using AI prompt, e.g. 'an image of a cat'>
-  - error_contains: <assert that these inputs throws an error, and that the error
-      message contains a string>
-    inputs:
+  - inputs:
       <input3>: <value3>
-test_hardware: <hardware, e.g. cpu>
-test_model: <test model, or empty to append '-test' to model>
+    error_contains: <assert that these inputs throws an error, and that the error
+      message contains a string>
+  fuzz:
+    fixed_inputs: {}
+    disabled_inputs: []
+    iterations: 10
 train:
   destination: <generated prediction model, e.g. andreasjansson/test-predict. leave
     blank to append '-dest' to the test model>
   destination_hardware: <hardware for the created prediction model, e.g. cpu>
-  fuzz:
-    disabled_inputs: []
-    fixed_inputs: {}
-    iterations: 10
+  train_timeout: 300
   test_cases:
-  - exact_string: <exact string match>
-    inputs:
+  - inputs:
       <input1>: <value1>
+    exact_string: <exact string match>
   - inputs:
       <input2>: <value2>
     match_url: <match output image against url>
   - inputs:
       <input3>: <value3>
     match_prompt: <match output using AI prompt, e.g. 'an image of a cat'>
-  - error_contains: <assert that these inputs throws an error, and that the error
-      message contains a string>
-    inputs:
+  - inputs:
       <input3>: <value3>
-  train_timeout: 300
-
-# values between < and > should be edited
-
-
-model: <model>
+    error_contains: <assert that these inputs throws an error, and that the error
+      message contains a string>
+  fuzz:
+    fixed_inputs: {}
+    disabled_inputs: []
+    iterations: 10
+deployment:
+  owner: <owner>
+  name: <name>
+  hardware: <hardware>
 parallel: 4
-predict:
-  compare_outputs: true
-  fuzz:
-    disabled_inputs: []
-    fixed_inputs: {}
-    iterations: 10
-  predict_timeout: 300
-  test_cases:
-  - exact_string: <exact string match>
-    inputs:
-      <input1>: <value1>
-  - inputs:
-      <input2>: <value2>
-    match_url: <match output image against url>
-  - inputs:
-      <input3>: <value3>
-    match_prompt: <match output using AI prompt, e.g. 'an image of a cat'>
-  - error_contains: <assert that these inputs throws an error, and that the error
-      message contains a string>
-    inputs:
-      <input3>: <value3>
-test_hardware: <hardware, e.g. cpu>
-test_model: <test model, or empty to append '-test' to model>
-train:
-  destination: <generated prediction model, e.g. andreasjansson/test-predict. leave
-    blank to append '-dest' to the test model>
-  destination_hardware: <hardware for the created prediction model, e.g. cpu>
-  fuzz:
-    disabled_inputs: []
-    fixed_inputs: {}
-    iterations: 10
-  test_cases:
-  - exact_string: <exact string match>
-    inputs:
-      <input1>: <value1>
-  - inputs:
-      <input2>: <value2>
-    match_url: <match output image against url>
-  - inputs:
-      <input3>: <value3>
-    match_prompt: <match output using AI prompt, e.g. 'an image of a cat'>
-  - error_contains: <assert that these inputs throws an error, and that the error
-      message contains a string>
-    inputs:
-      <input3>: <value3>
-  train_timeout: 300
+fast_push: false
+ignore_schema_compatibility: false
+official_model: <official model, e.g. user/model>
 
 # values between < and > should be edited
 ```

--- a/cog_safe_push/config.py
+++ b/cog_safe_push/config.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -89,6 +90,7 @@ class Config(BaseModel):
     parallel: int = 4
     fast_push: bool = False
     ignore_schema_compatibility: bool = False
+    official_model: Optional[str] = None
 
     def override(self, field: str, args: argparse.Namespace, arg: str):
         if hasattr(args, arg) and getattr(args, arg) is not None:

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -38,6 +38,7 @@ from .tasks import (
     RunTestCase,
     Task,
 )
+from .utils import parse_model
 
 DEFAULT_CONFIG_PATH = Path("cog-safe-push.yaml")
 
@@ -473,15 +474,6 @@ def parse_input_value(value: str) -> Any:
 
     # string
     return value
-
-
-def parse_model(model_owner_name: str) -> tuple[str, str]:
-    pattern = r"^([a-z0-9_-]+)/([a-z0-9-.]+)$"
-    match = re.match(pattern, model_owner_name)
-    if not match:
-        raise ArgumentError(f"Invalid model URL format: {model_owner_name}")
-    owner, name = match.groups()
-    return owner, name
 
 
 def parse_fuzz_fixed_inputs(

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -10,7 +10,7 @@ import pydantic
 import yaml
 from replicate.exceptions import ReplicateError
 
-from . import cog, deployment, lint, log, schema
+from . import cog, deployment, lint, log, official_model, schema
 from .config import (
     DEFAULT_PREDICT_TIMEOUT,
     Config,
@@ -146,6 +146,11 @@ def parse_args_and_config() -> tuple[Config, bool]:
     parser.add_argument(
         "model", help="Model in the format <owner>/<model-name>", nargs="?"
     )
+    parser.add_argument(
+        "--push-official-model",
+        help="Push to the official model defined in the config",
+        action="store_true",
+    )
     args = parser.parse_args()
 
     if args.verbose > 3:
@@ -197,6 +202,15 @@ def parse_args_and_config() -> tuple[Config, bool]:
 
 def run_config(config: Config, no_push: bool):
     assert config.test_model
+
+    if config.push_official_model:
+        if not config.official_model:
+            log.warning(
+                "No official model defined in config. Skipping official model push."
+            )
+            return
+        official_model.push_official_model(config.official_model)
+        return
 
     model_owner, model_name = parse_model(config.model)
     test_model_owner, test_model_name = parse_model(config.test_model)

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -14,6 +14,7 @@ from . import cog, deployment, lint, log, official_model, schema
 from .config import (
     DEFAULT_PREDICT_TIMEOUT,
     Config,
+    DeploymentConfig,
     FuzzConfig,
     PredictConfig,
     TrainConfig,
@@ -571,7 +572,12 @@ def print_help_config():
                 model="<model>",
                 test_model="<test model, or empty to append '-test' to model>",
                 test_hardware="<hardware, e.g. cpu>",
-                fast_push=False,
+                deployment=DeploymentConfig(
+                    owner="<owner>",
+                    name="<name>",
+                    hardware="<hardware>",
+                ),
+                official_model="<official model, e.g. user/model>",
                 predict=PredictConfig(
                     fuzz=FuzzConfig(),
                     test_cases=test_cases,
@@ -584,6 +590,7 @@ def print_help_config():
                 ),
             ).model_dump(exclude_none=True),
             default_flow_style=False,
+            sort_keys=False,
         ),
     )
     print("# values between < and > should be edited")

--- a/cog_safe_push/official_model.py
+++ b/cog_safe_push/official_model.py
@@ -1,10 +1,12 @@
 from . import cog
-from .log import log
+from .log import info
 from .task_context import get_or_create_model
 
 
-def push_official_model(official_model: str) -> None:
+def push_official_model(
+    official_model: str, dockerfile: str | None, fast_push: bool = False
+) -> None:
     owner, name = official_model.split("/")
     model = get_or_create_model(owner, name, "cpu")
-    log.info(f"Pushing to official model {official_model}")
-    cog.push(model)
+    info(f"Pushing to official model {official_model}")
+    cog.push(model, dockerfile, fast_push)

--- a/cog_safe_push/official_model.py
+++ b/cog_safe_push/official_model.py
@@ -1,0 +1,10 @@
+from . import cog
+from .log import log
+from .task_context import get_or_create_model
+
+
+def push_official_model(official_model: str) -> None:
+    owner, name = official_model.split("/")
+    model = get_or_create_model(owner, name, "cpu")
+    log.info(f"Pushing to official model {official_model}")
+    cog.push(model)

--- a/cog_safe_push/official_model.py
+++ b/cog_safe_push/official_model.py
@@ -1,12 +1,13 @@
 from . import cog
 from .log import info
+from .main import parse_model
 from .task_context import get_or_create_model
 
 
 def push_official_model(
     official_model: str, dockerfile: str | None, fast_push: bool = False
 ) -> None:
-    owner, name = official_model.split("/")
+    owner, name = parse_model(official_model)
     model = get_or_create_model(owner, name, "cpu")
     info(f"Pushing to official model {official_model}")
     cog.push(model, dockerfile, fast_push)

--- a/cog_safe_push/official_model.py
+++ b/cog_safe_push/official_model.py
@@ -1,7 +1,7 @@
 from . import cog
 from .log import info
-from .main import parse_model
 from .task_context import get_or_create_model
+from .utils import parse_model
 
 
 def push_official_model(

--- a/cog_safe_push/utils.py
+++ b/cog_safe_push/utils.py
@@ -1,5 +1,19 @@
+import re
+
+from .exceptions import ArgumentError
+
+
 def truncate(s, max_length=500) -> str:
     s = str(s)
     if len(s) <= max_length:
         return s
     return s[:max_length] + "..."
+
+
+def parse_model(model_owner_name: str) -> tuple[str, str]:
+    pattern = r"^([a-z0-9_-]+)/([a-z0-9-.]+)$"
+    match = re.match(pattern, model_owner_name)
+    if not match:
+        raise ArgumentError(f"Invalid model URL format: {model_owner_name}")
+    owner, name = match.groups()
+    return owner, name

--- a/end-to-end-test/test_end_to_end.py
+++ b/end-to-end-test/test_end_to_end.py
@@ -341,6 +341,12 @@ def test_cog_safe_push_create_official_model():
             )
             run_config(config, no_push=False, push_official_model=True)
 
+            # Verify the official model was created and has a version
+            official_model = replicate.models.get(
+                f"{model_owner}/{official_model_name}"
+            )
+            assert official_model.latest_version is not None
+
     finally:
         delete_model(model_owner, official_model_name)
 
@@ -360,7 +366,23 @@ def test_cog_safe_push_push_official_model():
                 official_model=f"{model_owner}/{official_model_name}",
                 test_hardware="cpu",
             )
+
+            official_model = replicate.models.get(
+                f"{model_owner}/{official_model_name}"
+            )
+            initial_version_id = (
+                official_model.latest_version.id
+                if official_model.latest_version
+                else None
+            )
+
             run_config(config, no_push=False, push_official_model=True)
+
+            official_model = replicate.models.get(
+                f"{model_owner}/{official_model_name}"
+            )
+            assert official_model.latest_version is not None
+            assert official_model.latest_version.id != initial_version_id
 
     finally:
         delete_model(model_owner, official_model_name)

--- a/end-to-end-test/test_end_to_end.py
+++ b/end-to-end-test/test_end_to_end.py
@@ -10,8 +10,9 @@ import replicate
 from replicate.exceptions import ReplicateException
 
 from cog_safe_push import log
+from cog_safe_push.config import Config
 from cog_safe_push.exceptions import *
-from cog_safe_push.main import cog_safe_push
+from cog_safe_push.main import cog_safe_push, run_config
 from cog_safe_push.output_checkers import (
     AIChecker,
     ErrorContainsChecker,
@@ -322,6 +323,47 @@ def test_cog_safe_push_deployment():
         # Models associated with a deployment are not deleted by default
         # We only delete the test model
         delete_model(model_owner, test_model_name)
+
+
+def test_cog_safe_push_create_official_model():
+    model_owner = "replicate-internal"
+    model_name = generate_model_name()
+    test_model_name = model_name + "-test"
+    official_model_name = model_name + "-official"
+
+    try:
+        with fixture_dir("image-base"):
+            config = Config(
+                model=f"{model_owner}/{model_name}",
+                test_model=f"{model_owner}/{test_model_name}",
+                official_model=f"{model_owner}/{official_model_name}",
+                test_hardware="cpu",
+            )
+            run_config(config, no_push=False, push_official_model=True)
+
+    finally:
+        delete_model(model_owner, official_model_name)
+
+
+def test_cog_safe_push_push_official_model():
+    model_owner = "replicate-internal"
+    model_name = generate_model_name()
+    test_model_name = model_name + "-test"
+    official_model_name = model_name + "-official"
+    create_model(model_owner, official_model_name)
+
+    try:
+        with fixture_dir("image-base"):
+            config = Config(
+                model=f"{model_owner}/{model_name}",
+                test_model=f"{model_owner}/{test_model_name}",
+                official_model=f"{model_owner}/{official_model_name}",
+                test_hardware="cpu",
+            )
+            run_config(config, no_push=False, push_official_model=True)
+
+    finally:
+        delete_model(model_owner, official_model_name)
 
 
 def generate_model_name():

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,6 +7,7 @@
     "**/node_modules",
     "**/__pycache__",
     "end-to-end-test/fixtures",
+    "venv"
   ],
 
   "ignore": [

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -12,27 +12,30 @@ from cog_safe_push.main import (
 
 def test_parse_args_minimal(monkeypatch):
     monkeypatch.setattr("sys.argv", ["cog-safe-push", "user/model"])
-    config, no_push = parse_args_and_config()
+    config, no_push, push_official_model = parse_args_and_config()
     assert config.model == "user/model"
     assert config.test_model == "user/model-test"
     assert not no_push
+    assert not push_official_model
 
 
 def test_parse_args_with_test_model(monkeypatch):
     monkeypatch.setattr(
         "sys.argv", ["cog-safe-push", "user/model", "--test-model", "user/test-model"]
     )
-    config, no_push = parse_args_and_config()
+    config, no_push, push_official_model = parse_args_and_config()
     assert config.model == "user/model"
     assert config.test_model == "user/test-model"
     assert not no_push
+    assert not push_official_model
 
 
 def test_parse_args_no_push(monkeypatch):
     monkeypatch.setattr("sys.argv", ["cog-safe-push", "user/model", "--no-push"])
-    config, no_push = parse_args_and_config()
+    config, no_push, push_official_model = parse_args_and_config()
     assert config.model == "user/model"
     assert no_push
+    assert not push_official_model
 
 
 def test_parse_args_verbose(monkeypatch):
@@ -51,7 +54,7 @@ def test_parse_args_predict_timeout(monkeypatch):
     monkeypatch.setattr(
         "sys.argv", ["cog-safe-push", "user/model", "--predict-timeout", "600"]
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.predict is not None
     assert config.predict.predict_timeout == 600
 
@@ -70,7 +73,7 @@ def test_parse_args_fuzz_options(monkeypatch):
             "5",
         ],
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.predict is not None
     assert config.predict.fuzz is not None
     assert config.predict.fuzz.fixed_inputs == {"key1": "value1", "key2": 42}
@@ -88,7 +91,7 @@ def test_parse_args_test_case(monkeypatch):
             "input1=value1;input2=42==expected output",
         ],
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.predict is not None
     assert len(config.predict.test_cases) == 1
     assert config.predict.test_cases[0].inputs == {"input1": "value1", "input2": 42}
@@ -107,7 +110,7 @@ def test_parse_args_multiple_test_cases(monkeypatch):
             "input2=value2~=AI prompt",
         ],
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.predict is not None
     assert len(config.predict.test_cases) == 2
     assert config.predict.test_cases[0].inputs == {"input1": "value1"}
@@ -146,7 +149,7 @@ def test_parse_config_file(tmp_path, monkeypatch):
     config_file.write_text(config_yaml)
     monkeypatch.setattr("sys.argv", ["cog-safe-push", "--config", str(config_file)])
 
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
 
     assert config.model == "user/model"
     assert config.test_model == "user/test-model"
@@ -186,7 +189,7 @@ def test_config_override_with_args(tmp_path, monkeypatch):
         ],
     )
 
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
 
     assert config.model == "user/model"
     assert config.test_model == "user/override-test-model"
@@ -227,7 +230,7 @@ def test_parse_args_no_compare_outputs(monkeypatch):
     monkeypatch.setattr(
         "sys.argv", ["cog-safe-push", "user/model", "--no-compare-outputs"]
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.predict is not None
     assert not config.predict.compare_outputs
 
@@ -236,7 +239,7 @@ def test_parse_args_fuzz_iterations(monkeypatch):
     monkeypatch.setattr(
         "sys.argv", ["cog-safe-push", "user/model", "--fuzz-iterations", "50"]
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.predict is not None
     assert config.predict.fuzz is not None
     assert config.predict.fuzz.iterations == 50
@@ -246,7 +249,7 @@ def test_parse_args_test_hardware(monkeypatch):
     monkeypatch.setattr(
         "sys.argv", ["cog-safe-push", "user/model", "--test-hardware", "gpu"]
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.test_hardware == "gpu"
 
 
@@ -269,7 +272,7 @@ def test_parse_config_with_train(tmp_path, monkeypatch):
     config_file.write_text(config_yaml)
     monkeypatch.setattr("sys.argv", ["cog-safe-push", "--config", str(config_file)])
 
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
 
     assert config.model == "user/model"
     assert config.test_model == "user/test-model"
@@ -294,7 +297,7 @@ def test_parse_args_with_default_config(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("sys.argv", ["cog-safe-push"])
 
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
 
     assert config.model == "user/default-model"
     assert config.test_model == "user/default-test-model"
@@ -310,7 +313,7 @@ def test_parse_args_override_default_config(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("sys.argv", ["cog-safe-push", "user/override-model"])
 
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
 
     assert config.model == "user/override-model"
     assert config.test_model == "user/default-test-model"
@@ -387,7 +390,7 @@ def test_parse_args_ignore_schema_compatibility(monkeypatch):
     monkeypatch.setattr(
         "sys.argv", ["cog-safe-push", "user/model", "--ignore-schema-compatibility"]
     )
-    config, _ = parse_args_and_config()
+    config, _, _ = parse_args_and_config()
     assert config.ignore_schema_compatibility is True
 
 
@@ -433,3 +436,13 @@ def test_parse_inputs():
 
     with pytest.raises(ArgumentError):
         parse_inputs(["invalid_format"])
+
+
+def test_parse_args_push_official_model(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv", ["cog-safe-push", "user/model", "--push-official-model"]
+    )
+    config, no_push, push_official_model = parse_args_and_config()
+    assert config.model == "user/model"
+    assert not no_push
+    assert push_official_model


### PR DESCRIPTION
Official models are defined in the yaml:

```yaml
official_model: user/model
```

They will be pushed (and created as CPU if they do not already exist) using a separate command using a `--push-official-model` flag. This is to allow modification of the model after a cog-safe-push run before pushing the official model (which is only used for generation API schema).

When official models generate their own API schema correctly and there is no need for an underlying model, we can remove this.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for creating and pushing official models in `cog-safe-push` with a new command-line flag and configuration option.
> 
>   - **Behavior**:
>     - Adds `--push-official-model` flag to `cog-safe-push` command to push official models defined in the config.
>     - Official models are created as CPU models if they do not exist.
>     - Skips official model push if `--no-push` is used or no official model is defined.
>   - **Configuration**:
>     - Adds `official_model` field to `Config` class in `config.py`.
>     - Updates `cog-safe-push.yaml` to include `official_model` configuration.
>   - **Functions**:
>     - Implements `push_official_model()` in `official_model.py` to handle pushing logic.
>     - Moves `parse_model()` to `utils.py` for reuse.
>   - **Tests**:
>     - Adds `test_cog_safe_push_create_official_model()` and `test_cog_safe_push_push_official_model()` in `test_end_to_end.py`.
>     - Adds `test_parse_args_push_official_model()` in `test_main.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fcog-safe-push&utm_source=github&utm_medium=referral)<sup> for 002053e064c972c2345788a329856e5b0b1651a0. You can [customize](https://app.ellipsis.dev/replicate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->