### PR TITLE
Config option to turn off using cog base images

### DIFF
--- a/cog_safe_push/cog.py
+++ b/cog_safe_push/cog.py
@@ -5,7 +5,11 @@ from . import log
 
 
 def push(
-    model_owner: str, model_name: str, dockerfile: str | None, fast_push: bool = False
+    model_owner: str,
+    model_name: str,
+    dockerfile: str | None,
+    fast_push: bool = False,
+    use_cog_base_image: bool = True,
 ) -> str:
     url = f"r8.im/{model_owner}/{model_name}"
     log.info(f"Pushing to {url}")
@@ -14,6 +18,8 @@ def push(
         cmd += ["--dockerfile", dockerfile]
     if fast_push:
         cmd += ["--x-fast"]
+    if not use_cog_base_image:
+        cmd += ["--use-cog-base-image=false"]
     process = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/cog_safe_push/config.py
+++ b/cog_safe_push/config.py
@@ -89,6 +89,7 @@ class Config(BaseModel):
     dockerfile: str | None = None
     parallel: int = 4
     fast_push: bool = False
+    use_cog_base_image: bool = True
     ignore_schema_compatibility: bool = False
     official_model: Optional[str] = None
 

--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -212,7 +212,10 @@ def run_config(config: Config, no_push: bool, push_official_model: bool):
             )
             return
         official_model.push_official_model(
-            config.official_model, config.dockerfile, config.fast_push
+            config.official_model,
+            config.dockerfile,
+            config.fast_push,
+            config.use_cog_base_image,
         )
         return
 
@@ -254,6 +257,7 @@ def run_config(config: Config, no_push: bool, push_official_model: bool):
             train_destination_name=destination_name,
             dockerfile=config.dockerfile,
             fast_push=config.fast_push,
+            use_cog_base_image=config.use_cog_base_image,
             deployment_name=deployment_name,
             deployment_owner=deployment_owner,
             deployment_hardware=deployment_hardware,
@@ -289,6 +293,7 @@ def run_config(config: Config, no_push: bool, push_official_model: bool):
             train=False,
             push_test_model=config.train is None,
             fast_push=config.fast_push,
+            use_cog_base_image=config.use_cog_base_image,
             deployment_name=deployment_name,
             deployment_owner=deployment_owner,
             deployment_hardware=deployment_hardware,
@@ -413,10 +418,11 @@ def cog_safe_push(
     if not no_push:
         log.info("Pushing model...")
         new_version = cog.push(
-            task_context.model.owner,
-            task_context.model.name,
-            task_context.dockerfile,
-            task_context.fast_push,
+            model_owner=task_context.model.owner,
+            model_name=task_context.model.name,
+            dockerfile=task_context.dockerfile,
+            fast_push=task_context.fast_push,
+            use_cog_base_image=task_context.use_cog_base_image,
         )
         deployment.handle_deployment(task_context, new_version)
 

--- a/cog_safe_push/official_model.py
+++ b/cog_safe_push/official_model.py
@@ -7,18 +7,33 @@ from .utils import parse_model
 
 
 def push_official_model(
-    official_model: str, dockerfile: str | None, fast_push: bool = False
+    official_model: str,
+    dockerfile: str | None,
+    fast_push: bool = False,
+    use_cog_base_image: bool = True,
 ) -> None:
     owner, name = parse_model(official_model)
     try:
         model = get_or_create_model(owner, name, "cpu")
         info(f"Pushing to official model {official_model}")
-        cog.push(model.owner, model.name, dockerfile, fast_push)
+        cog.push(
+            model_owner=model.owner,
+            model_name=model.name,
+            dockerfile=dockerfile,
+            fast_push=fast_push,
+            use_cog_base_image=use_cog_base_image,
+        )
     except ReplicateError as e:
         if e.status == 403:
             warning(
                 f"Could not get or create model {official_model} due to permission issues. Continuing with push..."
             )
-            cog.push(owner, name, dockerfile, fast_push)
+            cog.push(
+                model_owner=owner,
+                model_name=name,
+                dockerfile=dockerfile,
+                fast_push=fast_push,
+                use_cog_base_image=use_cog_base_image,
+            )
         else:
             raise

--- a/cog_safe_push/task_context.py
+++ b/cog_safe_push/task_context.py
@@ -15,6 +15,7 @@ class TaskContext:
     train_destination: Model | None
     dockerfile: str | None
     fast_push: bool
+    use_cog_base_image: bool
     deployment_name: str | None
     deployment_owner: str | None
     deployment_hardware: str | None
@@ -36,6 +37,7 @@ def make_task_context(
     train_destination_hardware: str = "cpu",
     push_test_model=True,
     fast_push: bool = False,
+    use_cog_base_image: bool = True,
     deployment_name: str | None = None,
     deployment_owner: str | None = None,
     deployment_hardware: str | None = None,
@@ -64,6 +66,7 @@ def make_task_context(
         train_destination=train_destination,
         dockerfile=dockerfile,
         fast_push=fast_push,
+        use_cog_base_image=use_cog_base_image,
         deployment_name=deployment_name,
         deployment_owner=deployment_owner,
         deployment_hardware=deployment_hardware,
@@ -77,7 +80,11 @@ def make_task_context(
 
     log.info("Pushing test model")
     pushed_version_id = cog.push(
-        test_model.owner, test_model.name, dockerfile, fast_push
+        model_owner=test_model.owner,
+        model_name=test_model.name,
+        dockerfile=dockerfile,
+        fast_push=fast_push,
+        use_cog_base_image=use_cog_base_image,
     )
     test_model.reload()
     try:


### PR DESCRIPTION
Hidden feature: Not exposed as a command line arg
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add hidden `use_cog_base_image` config option to control Cog base image usage in model push process.
> 
>   - **Behavior**:
>     - Add `use_cog_base_image` option to `push()` in `cog.py` to control Cog base image usage.
>     - Modify command in `push()` to include `--use-cog-base-image=false` if `use_cog_base_image` is `False`.
>   - **Config**:
>     - Add `use_cog_base_image` to `Config` class in `config.py`.
>     - Update `run_config()` and `cog_safe_push()` in `main.py` to pass `use_cog_base_image`.
>   - **Task Context**:
>     - Add `use_cog_base_image` to `TaskContext` class in `task_context.py`.
>     - Update `make_task_context()` to include `use_cog_base_image`.
>   - **Official Model**:
>     - Update `push_official_model()` in `official_model.py` to use `use_cog_base_image`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fcog-safe-push&utm_source=github&utm_medium=referral)<sup> for 388648340387d93742ad1aef7c4ca1fd1c70caee. You can [customize](https://app.ellipsis.dev/replicate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->