### PR TITLE
Show indexes before log lines

### DIFF
--- a/cog_safe_push/main.py
+++ b/cog_safe_push/main.py
@@ -365,6 +365,7 @@ def cog_safe_push(
             raise
 
     tasks = []
+    prediction_index = 1
 
     if model_has_versions:
         log.info("Checking schema backwards compatibility")
@@ -388,8 +389,10 @@ def cog_safe_push(
                     fuzz_fixed_inputs=fuzz_fixed_inputs,
                     fuzz_disabled_inputs=fuzz_disabled_inputs,
                     fuzz_prompt=fuzz_prompt,
+                    prediction_index=prediction_index,
                 )
             )
+            prediction_index += 1
 
     if test_cases:
         for inputs, checker in test_cases:
@@ -399,8 +402,10 @@ def cog_safe_push(
                     inputs=inputs,
                     checker=checker,
                     predict_timeout=predict_timeout,
+                    prediction_index=prediction_index,
                 )
             )
+            prediction_index += 1
 
     if fuzz_iterations > 0:
         fuzz_inputs_queue = Queue(maxsize=fuzz_iterations)
@@ -420,8 +425,10 @@ def cog_safe_push(
                     context=task_context,
                     inputs_queue=fuzz_inputs_queue,
                     predict_timeout=predict_timeout,
+                    prediction_index=prediction_index,
                 )
             )
+            prediction_index += 1
 
     asyncio.run(run_tasks(tasks, parallel=parallel))
 


### PR DESCRIPTION
Make logging make sense with prediction indexes.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `prediction_index` to log lines and error messages for better traceability of predictions in `cog_safe_push` tasks.
> 
>   - **Logging Enhancements**:
>     - Add `prediction_index` to log lines in `predict()` in `predict.py` and `run()` methods in `tasks.py`.
>     - Prefix log messages with `prediction_index` for better traceability.
>   - **Task Management**:
>     - Initialize and increment `prediction_index` in `cog_safe_push()` in `main.py` for each task.
>     - Pass `prediction_index` to `CheckOutputsMatch`, `RunTestCase`, and `FuzzModel` tasks in `tasks.py`.
>   - **Error Handling**:
>     - Include `prediction_index` in error messages in `tasks.py` for `OutputsDontMatchError` and `FuzzError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fcog-safe-push&utm_source=github&utm_medium=referral)<sup> for 2178cbf5e8603dd9287f259018358f00cd29286c. You can [customize](https://app.ellipsis.dev/replicate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->