### PR TITLE
timeout error now with text

### DIFF
--- a/cog_safe_push/predict.py
+++ b/cog_safe_push/predict.py
@@ -271,7 +271,7 @@ async def predict(
     while prediction.status not in ["succeeded", "failed", "canceled"]:
         await asyncio.sleep(0.5)
         if time.time() - start_time > timeout_seconds:
-            raise PredictionTimeoutError()
+            raise PredictionTimeoutError(f"{prefix} Prediction timed out after {timeout_seconds} seconds")
         prediction.reload()
 
     duration = time.time() - start_time


### PR DESCRIPTION
Looks like there are two places where predictions can time out in safe push, one of which had no error text. Adding some so that it's easier for for folks to piece out why their safe push fails in the future. 